### PR TITLE
Support ':' in package names

### DIFF
--- a/source/dubregistry/registry.d
+++ b/source/dubregistry/registry.d
@@ -228,7 +228,7 @@ private void checkPackageName(string n){
 			case 'a': .. case 'z':
 			case 'A': .. case 'Z':
 			case '0': .. case '9':
-			case '_', '-':
+			case '_', '-', ':':
 				break;
 		}
 	}


### PR DESCRIPTION
When using sub-packages (or depending on sub-packages) in a package.json file, the dub registry will say in red:

"Branch ~master: Package names may only contain ASCII letters and numbers, as well as '_' and '-': gfm:math"
This hopefully fixes this.
I haven't be able to test this pull request.
