### PR TITLE
Added `filesystem` and `gamedev` categories

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -45,6 +45,8 @@
 		{"name": "data", "description": "Data storage and format support"},
 		{"name": "data_structures", "description": "Data Structures and Containers"},
 		{"name": "database", "description": "Database clients or implementations"},
+		{"name": "filesystem", "description": "File system libraries"},
+		{"name": "gamedev", "description": "Libraries aimed at game development"},
 		{"name": "graphics", "description": "2D/3D graphics"},
 		{"name": "gui", "description": "Graphical user interfaces"},
 		{"name": "network", "description": "Networking libraries", "categories": [


### PR DESCRIPTION
- `filesystem` for my D:GameVFS library (could also add `virtual-filesystem` but I think that would be too specific)
- `gamedev` - various gamedev-oriented libraries may fit various categories, but I think it'd be good to have one category to be able to find gamedev libraries regardless of whether they are graphics, networking, physics, VFS as in my case or whatever.
