### PR TITLE
Search functionality for dub CLI

### DIFF
--- a/source/dubregistry/api.d
+++ b/source/dubregistry/api.d
@@ -46,4 +46,45 @@ class DubRegistryWebApi {
 		if (stats.type != Json.Type.null_) res.writeJsonBody(stats);
 		else res.writeJsonBody(["message": "Package/Version not found"], HTTPStatus.notFound);
 	}
+
+    // searches for a package
+    void querySearch(HTTPServerRequest req, HTTPServerResponse res){
+        string* q = "q" in req.query;
+        
+        if(q == null) 
+        {
+            res.statusCode = 400;
+            res.writeJsonBody("Error: Must pass query parameter");
+            logDiagnostic("Error: no query in search string");
+            return;
+        }
+
+        string[] queryStrings = (*q).split(",");
+
+        if(queryStrings.length == 0)
+        {
+            res.statusCode = 400;
+            res.writeJsonBody("Error: Must pass search text");
+            logDiagnostic("Error: no query parameters in search string");
+            return;
+        }
+        // limit the number of items can search for, to limit possibility for attacks
+        // should maybe pick a better number here, 15 is arbitrary limit I chose
+        if(queryStrings.length > 15)
+        {
+            res.statusCode = 400;
+            res.writeJsonBody("Error: Search for <= 15 packages at a time");
+            logDiagnostic(format("Error: too many parameters in search string : %s", queryStrings));
+            return;
+        }
+ 
+        // do the search, putting the results into a json object
+        Json json = Json.emptyObject;
+        foreach(str; queryStrings){
+            json[str] = m_registry.searchPackages([str])
+                .map!( a => a["name"] ).array;  // pull the name field out of the package json data
+        }
+        res.statusCode = 200;
+        res.writeJsonBody(json);
+    }
 }

--- a/source/dubregistry/api.d
+++ b/source/dubregistry/api.d
@@ -47,44 +47,37 @@ class DubRegistryWebApi {
 		else res.writeJsonBody(["message": "Package/Version not found"], HTTPStatus.notFound);
 	}
 
-    // searches for a package
-    void querySearch(HTTPServerRequest req, HTTPServerResponse res){
-        string* q = "q" in req.query;
-        
-        if(q == null) 
-        {
-            res.statusCode = 400;
-            res.writeJsonBody("Error: Must pass query parameter");
-            logDiagnostic("Error: no query in search string");
-            return;
-        }
+	// searches for a package
+	void querySearch(HTTPServerRequest req, HTTPServerResponse res){
+		logDiagnostic("Performing search query. Raw query data: %s", req.query);
 
-        string[] queryStrings = (*q).split(",");
+		import std.uri : decodeComponent; // decodes the URI as it was encoded on the dub end using encodeComponent
+		auto queries = req.query.get("q", "").splitter("%2C").map!(a => a.decodeComponent).array;
+		if(queries.empty)
+		{
+			res.statusCode = 400;
+			res.writeJsonBody("Error: Must pass query parameter");
+			logDiagnostic("Error: no query in search string");
+			return;
+		}
 
-        if(queryStrings.length == 0)
-        {
-            res.statusCode = 400;
-            res.writeJsonBody("Error: Must pass search text");
-            logDiagnostic("Error: no query parameters in search string");
-            return;
-        }
-        // limit the number of items can search for, to limit possibility for attacks
-        // should maybe pick a better number here, 15 is arbitrary limit I chose
-        if(queryStrings.length > 15)
-        {
-            res.statusCode = 400;
-            res.writeJsonBody("Error: Search for <= 15 packages at a time");
-            logDiagnostic(format("Error: too many parameters in search string : %s", queryStrings));
-            return;
-        }
- 
-        // do the search, putting the results into a json object
-        Json json = Json.emptyObject;
-        foreach(str; queryStrings){
-            json[str] = m_registry.searchPackages([str])
-                .map!( a => a["name"] ).array;  // pull the name field out of the package json data
-        }
-        res.statusCode = 200;
-        res.writeJsonBody(json);
-    }
+		// limit the number of items can search for, to limit possibility for attacks
+		// should maybe pick a better number here, 15 is arbitrary limit I chose
+		if(queries.length > 15)
+		{
+			res.statusCode = 400;
+			res.writeJsonBody("Error: Search for <= 15 packages at a time");
+			logDiagnostic(format("Error: too many parameters in search string : %s", queries));
+			return;
+		}
+
+		// do the search, putting the results into a json object
+		Json json = Json.emptyObject;
+		foreach(str; queries){
+			json[str] = m_registry.searchPackages([str])
+				.map!( a => a["name"] ).array;  // pull the name field out of the package json data
+		}
+		res.statusCode = 200;
+		res.writeJsonBody(json);
+	}
 }


### PR DESCRIPTION
Adds a function to api.d to support searching for packges for the dub command line tool.

Used by:
https://github.com/D-Programming-Language/dub/pull/515

It is accessible through:
/api/search?q=<comma,seperated,names>

and returns a json string with format
{
    "searched for string" : [ "closely", "matching", "values"]
}

It uses the m_registry.searchPackages function to do the actual searching, so if/when this is updated to run with elastic search it should slot right in.