### PR TITLE
Add warning when registering a fork

### DIFF
--- a/source/dubregistry/registry.d
+++ b/source/dubregistry/registry.d
@@ -111,6 +111,12 @@ class DubRegistry {
 			Info(p.name, m_db.getVersionInfo(p.name, p.versions[$ - 1].version_)));
 	}
 
+	RepositoryInfo getRepositoryInfo(Json repository)
+	{
+		auto rep = getRepository(repository);
+		return rep.getInfo();
+	}
+
 	void addPackage(Json repository, User.ID user)
 	{
 		auto pack_name = validateRepository(repository);

--- a/source/dubregistry/repositories/bitbucket.d
+++ b/source/dubregistry/repositories/bitbucket.d
@@ -67,6 +67,14 @@ class BitbucketRepository : Repository {
 		return ret;
 	}
 
+	RepositoryInfo getInfo()
+	{
+		auto nfo = readJson("https://api.bitbucket.org/1.0/repositories/"~m_owner~"/"~m_project);
+		RepositoryInfo ret;
+		ret.isFork = nfo["is_fork"].opt!bool;
+		return ret;
+	}
+
 	void readFile(string commit_sha, Path path, scope void delegate(scope InputStream) reader)
 	{
 		assert(path.absolute, "Passed relative path to readFile.");

--- a/source/dubregistry/repositories/github.d
+++ b/source/dubregistry/repositories/github.d
@@ -75,6 +75,14 @@ class GithubRepository : Repository {
 		return ret;
 	}
 
+	RepositoryInfo getInfo()
+	{
+		auto nfo = readJson(getAPIURLPrefix()~"/repos/"~m_owner~"/"~m_project);
+		RepositoryInfo ret;
+		ret.isFork = nfo["fork"].opt!bool;
+		return ret;
+	}
+
 	void readFile(string commit_sha, Path path, scope void delegate(scope InputStream) reader)
 	{
 		assert(path.absolute, "Passed relative path to readFile.");

--- a/source/dubregistry/repositories/repository.d
+++ b/source/dubregistry/repositories/repository.d
@@ -38,9 +38,14 @@ alias RepositoryFactory = Repository delegate(Json);
 interface Repository {
 	RefInfo[] getTags();
 	RefInfo[] getBranches();
+	RepositoryInfo getInfo();
 	void readFile(string commit_sha, Path path, scope void delegate(scope InputStream) reader);
 	string getDownloadUrl(string tag_or_branch);
 	void download(string tag_or_branch, scope void delegate(scope InputStream) del);
+}
+
+struct RepositoryInfo {
+	bool isFork;
 }
 
 struct RefInfo {

--- a/views/my_packages.register.dt
+++ b/views/my_packages.register.dt
@@ -7,15 +7,15 @@ block body
 
 	form(method="POST", action="#{req.rootDir}register_package")
 		select(name="kind", size="1")
-			option(value="github", selected=req.form.get("kind", "") == "github") GitHub project
-			option(value="bitbucket", selected=req.form.get("kind", "") == "bitbucket") Bitbucket project
-			//-option(value="gitlab", selected=req.form.get("kind", "") == "gitlab") GitLab project
+			option(value="github", selected=kind == "github") GitHub project
+			option(value="bitbucket", selected=kind == "bitbucket") Bitbucket project
+			//-option(value="gitlab", selected=kind == "gitlab") GitLab project
 		p
 			label(for="owner") Repository owner:
-			input(type="text", name="owner", value=req.form.get("owner", ""))
+			input(type="text", name="owner", value=owner)
 		p
 			label(for="project") Repository name:
-			input(type="text", name="project", value=req.form.get("project", ""))
+			input(type="text", name="project", value=project)
 		- if (error.length)
 			p.error
 				- foreach (ln; error.splitLines)

--- a/views/my_packages.register.warn_fork.dt
+++ b/views/my_packages.register.warn_fork.dt
@@ -1,0 +1,23 @@
+extends layout
+
+block title
+	- auto title = "Register forked repository?";
+	
+block body
+
+	p.warn <strong>Warning:</strong> You are about to register a forked repository. Please make sure to use a name for your package that is unique to your fork, and try to get in touch with the original author first. Not doing so may result in your fork getting removed at a later point.
+
+	p
+		form(method="POST", action='#{req.rootDir}register_package')
+			input(type="hidden", name="kind", value=kind)
+			input(type="hidden", name="owner", value=owner)
+			input(type="hidden", name="project", value=project)
+			input(type="hidden", name="ignore_fork", value=true)
+			button(type="submit") Yes, I'm using a unique name, let me register now!
+
+	p
+		form(method="GET", action="#{req.rootDir}register_package")
+			input(type="hidden", name="kind", value=kind)
+			input(type="hidden", name="owner", value=owner)
+			input(type="hidden", name="project", value=project)
+			button(type="submit") No, take me back, I still have to sort this out.


### PR DESCRIPTION
It happened now a couple of times (e.g. to @adamdruppe and @Hackerpilot) that someone forked a popular repository to register it on code.dlang.org. Later, the original authors tried to do the same, discovering that the name is already taken. To make people aware of this issue, this now adds a warning whenever a forked repository is detected.