### PR TITLE
Redesign part 2

### DIFF
--- a/public/styles/top_p.css
+++ b/public/styles/top_p.css
@@ -54,3 +54,17 @@ h2 {
   font-weight: normal;
   font-style: normal;
 }
+
+/* minimal font awesome CSS */
+
+.fa {
+  display: inline-block;
+  font: normal normal normal 14px/1 FontAwesome;
+  font-size: inherit;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+.fa-search:before {
+  content: "\f002";
+}

--- a/public/styles/top_p.css
+++ b/public/styles/top_p.css
@@ -16,8 +16,19 @@ table {
 	float: none;
 	margin-right: 0;
 	display: inline-block;
-	margin-left: -15px;
+	margin-left: 0px;
 	padding-right: 15px;
+}
+
+/* let dlang header have same padding as content */
+
+@media (min-width: 600pt) {
+    #top > .helper {
+        padding-left: 10%;
+        padding-right: 10%;
+        margin: 0;
+        max-width: initial;
+    }
 }
 
 @media only screen and (max-width:54em) {

--- a/views/layout.dt
+++ b/views/layout.dt
@@ -21,11 +21,10 @@ html
 					a(href="#", title="Menu", class="hamburger expand-toggle")
 						span Menu
 					#cssmenu
-						- auto listitems = [tuple("Packages", [""]), tuple("Documentation", ["Getting Started;getting_started", "Development;develop", "Package format (JSON);package-format?lang=json", "Package format (SDLang);package-format?lang=sdl"]), tuple("About",  ["Forums;http://forum.rejectedsoftware.com/groups/rejectedsoftware.dub", "Bug tracker (website);https://github.com/D-Programming-Language/dub-registry/issues", "Bug tracker (DUB);https://github.com/D-Programming-Language/dub/issues", "Github repository (website);https://github.com/D-Programming-Language/dub-registry", "GitHub repository (DUB);https://github.com/D-Programming-Language/dub"])];
+						- auto listitems = [tuple("Packages", [""]), tuple("Documentation", ["Getting Started;getting_started", "Development;develop", "Package format (JSON);package-format?lang=json", "Package format (SDLang);package-format?lang=sdl"]), tuple("About",  ["Forums;http://forum.rejectedsoftware.com/groups/rejectedsoftware.dub", "Bug tracker (website);https://github.com/D-Programming-Language/dub-registry/issues", "Bug tracker (DUB);https://github.com/D-Programming-Language/dub/issues", "Github repository (website);https://github.com/D-Programming-Language/dub-registry", "GitHub repository (DUB);https://github.com/D-Programming-Language/dub"]), tuple("Download", ["download"])];
 						- if( req.session )
 							- listitems ~= tuple("My account", ["Log out;logout", "Edit profile;profile"]);
 						- else
-							- listitems ~= tuple("Register", ["register"]);
 							- auto loginURL = req.requestURL;
 							- if( loginURL == "/")
 								- loginURL = "/my_packages";

--- a/views/layout.dt
+++ b/views/layout.dt
@@ -67,7 +67,7 @@ html
 									input#q(name="q", placeholder="Search for a package")
 								span#search-submit
 									button(type="submit")
-										i.fa.fa-search Go
+										i.fa.fa-search
 
 		#content
 			block body


### PR DESCRIPTION
(follow-up to #141)

> The top bar should have its contents aligned with the main contents. The logo in particular should start at the same column as the text below. 

Done.

> The search button should just have the word "Go" dropped, the loupe is enough and also too close to the "Go" ATM.

I didn't update the alpha server after @MartinNowak PR - it was just "Go". This PR replaces the word "Go" back to the loupe.

@s-ludwig Anything else that's blocking the new design?

(Changes are uploaded to alpha.dub.pm again - we might want to create some CI at some point)