### PR TITLE
Codeberg projects should work, assuming gitea support works.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Running as a mirror
 dub -- --mirror=https://code.dlang.org
 ```
 
-GitHub/GitLab API
+GitHub/GitLab/Gitea (Codeberg) API
 -----------------
 
 By default the GitHub/GitLab update cron job will use anonymous authentication on your local machine. As GitHub's API without authentication is quite rate-limited, you probably want to use authenticated API requests.
@@ -36,7 +36,9 @@ You can do so by creating a `settings.json` in the root folder of the dub-regist
 	"gitlab-url": "https://gitlab.com/",
 	"gitlab-auth": "<gitlab-api-token from https://gitlab.com/-/profile/personal_access_tokens>",
 	"bitbucket-user": "<your-fancy-user-name>",
-	"bitbucket-password": "<your-fancy-password>"
+	"bitbucket-password": "<your-fancy-password>",
+	"gitea-url": "https://codeberg.org/",
+	"gitea-auth": "<gitea/forgejo API token (Codeberg: Settings -> Applications -> New Token)>"
 }
 ```
 
@@ -47,6 +49,15 @@ It's absolutely recommended to create a personal access token without any extra 
 ### SECURITY NOTICE
 
 Development versions prior to 2.3.0 were leaking the GitLab private token in error messages shown to the user. Please make sure to use the latest version along with a freshly generated token.
+
+### Codeberg support (via Gitea/Forgejo)
+
+Codeberg runs Forgejo, a fork of Gitea. dub-registry supports generic Gitea/Forgejo instances. To enable Codeberg support:
+
+- Set `gitea-url` to `https://codeberg.org/` in your `settings.json` (or use env var `GITEA_URL`).
+- (Optional) Set `gitea-auth` to a personal access token for higher API rate limits and to access private repositories (env var `GITEA_AUTH`).
+
+Note: currently only a single Gitea/Forgejo instance can be configured at a time.
 
 Running without the cron job
 ----------------------------

--- a/source/dubregistry/repositories/gitea.d
+++ b/source/dubregistry/repositories/gitea.d
@@ -104,7 +104,9 @@ class GiteaRepository : Repository {
 		m_authToken = auth_token;
 		m_url = url;
 		if (m_url[$-1] != '/') m_url ~= "/";
-		m_public = m_url == "https://gitea.com/"; // TODO: determine from repsitory
+		// Consider well-known public Gitea/Forgejo hosts as "public" to allow direct downloads
+		// Note: Codeberg runs Forgejo (Gitea fork) and supports the same archive URLs
+		m_public = m_url.startsWith("https://gitea.com/") || m_url.startsWith("https://codeberg.org/");
 	}
 
 	RefInfo[] getTags()
@@ -222,7 +224,9 @@ class GiteaRepository : Repository {
 
 	private void addAuthentication(scope HTTPClientRequest req)
 	{
-		req.headers["Authorization"] = "token " ~ m_authToken;
+		// Only add Authorization header if a token is provided
+		if (m_authToken.length)
+			req.headers["Authorization"] = "token " ~ m_authToken;
 	}
 
 	private string getAPIURLPrefix()

--- a/views/my_packages.register.dt
+++ b/views/my_packages.register.dt
@@ -21,7 +21,7 @@ block body
 		form(method="POST", action="#{req.rootDir}register_package")
 			p
 				label(for="project") Repository URL
-				input(type="text", name="url", value=url, pattern="^(https?:\/\/)?(www\.)?(((github(\.com)?|bitbucket(\.org)?)\/[^/]+\/[^/]+([?#.].*)?)|(gitlab(\.com)?(\/[^/]+)+\/[^/]+([?#.].*)?))$", placeholder="github.com/user/repository")
-				span.repoError Please enter a valid project URL or tuple to a GitHub, GitLab or BitBucket project, such as #[code https://gitlab.com/dlang/dub] or #[code bitbucket/dlang/dub].
+				input(type="text", name="url", value=url, pattern="^(https?:\/\/)?(www\.)?(((github(\.com)?|bitbucket(\.org)?|codeberg(\.org)?)\/[^/]+\/[^/]+([?#.].*)?)|(gitlab(\.com)?(\/[^/]+)+\/[^/]+([?#.].*)?))$", placeholder="github.com/user/repository")
+				span.repoError Please enter a valid project URL or tuple to a GitHub, GitLab, Codeberg or BitBucket project, such as #[code https://gitlab.com/dlang/dub] or #[code bitbucket/dlang/dub].
 			p
 				button(type="submit") Register package


### PR DESCRIPTION
All my projects are on Codeberg and I am sick of having to setup mirrors to GitLab just because of DUB... Please help making it possible to register Codeberg projects on DUB.

If this works, it should close the #554