### PR TITLE
Fix corrupted webhook URLs when package secret is in the page query

### DIFF
--- a/views/my_packages.package.dt
+++ b/views/my_packages.package.dt
@@ -128,6 +128,9 @@ block body
 			.inputForm
 				- auto apiUrl = req.fullURL;
 				- apiUrl.path = typeof(apiUrl.path).init;
+				- apiUrl.queryString = null;
+				- apiUrl.anchor = null;
+				- if (apiUrl.port == apiUrl.defaultPort) apiUrl.port = 0;
 				#secret-guide(style=secret.length ? "" : "display: none")
 					- auto placeholder = secret.length ? secret : "{SECRET}";
 					p A webhook secret for this package is configured.
@@ -145,6 +148,7 @@ block body
 						label(for="secret") Secret:
 						input#secret(type="text", readonly, autocomplete="off", value=placeholder)
 					p.warn This secret will only be shown once, please make sure to note it down.
+					p Example test (must use POST and Content-Type application/json): ``curl -X POST -H "Content-Type: application/json" -d "{}" "#{apiUrl}/api/packages/#{packageName}/update/github?secret=#{placeholder}"``
 					p Read more in the #[a(href="https://github.com/dlang/dub/blob/master/docs/http-update.md", target="_blank") API documentation]
 					hr
 				- if (secretBcrypt.length)


### PR DESCRIPTION
## Summary

After Enable/Regenerate Secret, the package page redirects to `/my_packages/:name?secret=SECRET#repository`. The webhook URL builder used `req.fullURL` and only cleared the path, so the page query (and fragment) remained in the base URL.

**Before** (what the UI showed / users pasted into GitHub):
```
https://code.dlang.org:443?secret=SECRET/api/packages/NAME/update/github?secret=SECRET
```

**After**:
```
https://code.dlang.org/api/packages/NAME/update/github?secret=SECRET
```

## Changes

- In `views/my_packages.package.dt`, after clearing `apiUrl.path`, also clear `queryString` and `anchor`, and set `port = 0` when it is the schema default (drops `:443` from displayed URLs).
- Add a one-line `curl` example under the secret guide so users know to POST with `Content-Type: application/json` (otherwise the endpoint returns 400).

## Refs

- Fixes #614
- Cited by CyberShadow on #603: https://github.com/dlang/dub-registry/pull/603#issuecomment-3740684529
- User report (wrong repo): dlang/dub#3121

Note: Content-Type must be `application/json` for webhook POSTs; mentioned in the new curl example and here for reviewers.

Made with [Cursor](https://cursor.com)