### PR TITLE
Render AsciiDoc package READMEs on the Info tab

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -11,8 +11,10 @@ dependency "botan" version="*" # needs bcrypt, available since initial release
 dependency "dub" version="~>1.33"
 dependency "userman" version="~>0.4.0"
 dependency "uritemplate" version="~>1.0.0"
+dependency "asciidoctor-d" version="~feature/html5-fragment-safe" repository="git+https://github.com/dlang-supplemental/asciidoctor-d.git"
 subConfiguration "dub" "library-nonet"
 subConfiguration "botan" "full" # full = everything excluding openssl (needed for bcrypt)
+subConfiguration "asciidoctor-d" "library"
 
 //versions "VibeJsonFieldNames"
 

--- a/public/styles/asciidoc.css
+++ b/public/styles/asciidoc.css
@@ -1,0 +1,83 @@
+/* Lightweight AsciiDoc fragment styles for the package Info tab */
+
+.asciidoc-body #header h1 {
+  margin-top: 0;
+}
+
+.asciidoc-body .sect1 + .sect1,
+.asciidoc-body .sect2 + .sect2 {
+  margin-top: 1.5em;
+}
+
+.asciidoc-body .listingblock,
+.asciidoc-body .literalblock {
+  margin: 1em 0;
+}
+
+.asciidoc-body .listingblock pre,
+.asciidoc-body .literalblock pre {
+  padding: 16px;
+  overflow: auto;
+  font-size: 85%;
+  line-height: 1.45;
+  background-color: #f7f7f7;
+  border-radius: 3px;
+}
+
+.asciidoc-body .admonitionblock {
+  margin: 1em 0;
+  padding: 0.75em 1em;
+  border-left: 4px solid #ddd;
+  background: #f8f8f8;
+}
+
+.asciidoc-body .admonitionblock.note { border-left-color: #3572A5; }
+.asciidoc-body .admonitionblock.tip { border-left-color: #2ea44f; }
+.asciidoc-body .admonitionblock.warning,
+.asciidoc-body .admonitionblock.caution { border-left-color: #d73a49; }
+.asciidoc-body .admonitionblock.important { border-left-color: #e36209; }
+
+.asciidoc-body .admonitionblock .title {
+  font-weight: bold;
+  margin-bottom: 0.25em;
+}
+
+.asciidoc-body .imageblock {
+  margin: 1em 0;
+}
+
+.asciidoc-body .imageblock img {
+  max-width: 100%;
+}
+
+.asciidoc-body .quoteblock {
+  margin: 1em 0;
+  padding-left: 1em;
+  border-left: 4px solid #ddd;
+  color: #555;
+}
+
+.asciidoc-body .sidebarblock {
+  margin: 1em 0;
+  padding: 1em;
+  background: #f6f8fa;
+  border-radius: 3px;
+}
+
+.asciidoc-body table.tableblock {
+  border-collapse: collapse;
+  margin: 1em 0;
+  width: 100%;
+}
+
+.asciidoc-body table.tableblock th,
+.asciidoc-body table.tableblock td {
+  border: 1px solid #ddd;
+  padding: 6px 13px;
+}
+
+.asciidoc-body .plain-readme {
+  white-space: pre-wrap;
+  font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  font-size: 85%;
+}

--- a/source/dubregistry/dbcontroller.d
+++ b/source/dubregistry/dbcontroller.d
@@ -696,7 +696,12 @@ struct DbPackageVersion {
 	@optional string commitID;
 	Json info;
 	@optional string readme;
+	/// Legacy flag kept for older DB documents; prefer `readmeFormat`.
 	@optional bool readmeMarkdown;
+	/// One of: "markdown", "asciidoc", "plain". Empty means derive from `readmeMarkdown`.
+	@optional string readmeFormat;
+	/// Original README filename in the repository (e.g. README.adoc), for link rewriting.
+	@optional string readmeFile;
 	@optional string docFolder;
 }
 

--- a/source/dubregistry/registry.d
+++ b/source/dubregistry/registry.d
@@ -314,6 +314,13 @@ class DubRegistry {
 			nfo["date"] = v.date.toISOExtString();
 			nfo["readme"] = v.readme;
 			nfo["commitID"] = v.commitID;
+			auto fmt = v.readmeFormat;
+			// Historical default: Info tab always ran the Markdown filter.
+			if (!fmt.length)
+				fmt = "markdown";
+			nfo["readmeFormat"] = fmt;
+			if (v.readmeFile.length)
+				nfo["readmeFile"] = v.readmeFile;
 		}
 		nfo["version"] = v.version_;
 
@@ -590,30 +597,35 @@ class DubRegistry {
 
 		try {
 			auto files = rep.listFiles(reference.sha, InetPath("/"));
-			// check exactly for readme.me
-			ptrdiff_t readme;
-			readme = files.countUntil!(a => a.type == RepositoryFile.Type.file && a.path.head.name.asUpperCase.equal("README.MD"));
-			if (readme == -1) {
-				// check exactly for readme
-				readme = files.countUntil!(a => a.type == RepositoryFile.Type.file && a.path.head.name.asUpperCase.equal("README"));
+			// Prefer README.md, then README.adoc / README.asciidoc, then bare README, then other README*
+			ptrdiff_t readme = -1;
+			foreach (name; ["README.MD", "README.ADOC", "README.ASCIIDOC", "README"]) {
+				readme = files.countUntil!(a => a.type == RepositoryFile.Type.file
+					&& a.path.head.name.asUpperCase.equal(name));
+				if (readme != -1) break;
 			}
 			if (readme == -1) {
 				// check for all other readmes such as README.txt, README.jp.md, etc.
-				readme = files.countUntil!(a => a.type == RepositoryFile.Type.file && a.path.head.name.asUpperCase.startsWith("README"));
+				readme = files.countUntil!(a => a.type == RepositoryFile.Type.file
+					&& a.path.head.name.asUpperCase.startsWith("README"));
 			}
 
 			if (readme != -1) {
-				rep.readFile(reference.sha, files[readme].path, (scope input) {
+				auto readmePath = files[readme].path;
+				auto readmeName = readmePath.head.name.to!string;
+				auto readmeExt = readmePath.head.extension.to!string;
+				rep.readFile(reference.sha, readmePath, (scope input) @safe {
 					dbver.readme = input.readAllUTF8();
-					auto ext = files[readme].path.head.extension;
-					// endsWith doesn't like to work with asLowerCase
-					dbver.readmeMarkdown = ext.sicmp(".md") == 0;
+					dbver.readmeFile = readmeName;
+					import dubregistry.viewutils : readmeFormatFromExtension;
+					dbver.readmeFormat = readmeFormatFromExtension(readmeExt);
+					dbver.readmeMarkdown = dbver.readmeFormat == "markdown";
 				});
-			} else logDiagnostic("No README.md found for %s %s", dbpack.name, ver);
+			} else logDiagnostic("No README found for %s %s", dbpack.name, ver);
 
 			// TODO: load in example(s), sample(s), test(s) and docs for the view package page here.
 			// possibly also parsing the README.md file for a documentation link
-		} catch (Exception e) { logDiagnostic("Failed to read README.md for %s %s: %s", dbpack.name, ver, e.msg); }
+		} catch (Exception e) { logDiagnostic("Failed to read README for %s %s: %s", dbpack.name, ver, e.msg); }
 
 		if (m_db.hasVersion(dbpack.name, ver)) {
 			logDebug("Updating existing version info.");

--- a/source/dubregistry/viewutils.d
+++ b/source/dubregistry/viewutils.d
@@ -7,6 +7,7 @@ module dubregistry.viewutils;
 
 import std.datetime;
 import std.string;
+import std.algorithm : canFind;
 import vibe.data.json;
 
 string formatDate(Json date)
@@ -128,4 +129,102 @@ unittest {
 	assert(getBestVersionIndex(["~somebranch", "~master"]) == 1);
 	assert(getBestVersionIndex(["~master", "~somebranch"]) == 0);
 	assert(getBestVersionIndex(["1.0.0", "1.0.1-alpha"]) == 1);
+}
+
+/** Detect README markup format from a file extension (including the leading dot). */
+string readmeFormatFromExtension(string ext) @safe
+{
+	import std.uni : sicmp;
+	if (ext.sicmp(".md") == 0 || ext.sicmp(".markdown") == 0)
+		return "markdown";
+	if (ext.sicmp(".adoc") == 0 || ext.sicmp(".asciidoc") == 0 || ext.sicmp(".asc") == 0)
+		return "asciidoc";
+	return "plain";
+}
+
+unittest {
+	assert(readmeFormatFromExtension(".md") == "markdown");
+	assert(readmeFormatFromExtension(".ADOC") == "asciidoc");
+	assert(readmeFormatFromExtension(".asciidoc") == "asciidoc");
+	assert(readmeFormatFromExtension(".txt") == "plain");
+	assert(readmeFormatFromExtension("") == "plain");
+}
+
+/**
+	Render a package README to HTML for the Info tab.
+
+	Markdown uses vibe-d's filter (no inline HTML). AsciiDoc uses asciidoctor-d
+	in secure fragment mode. Plain text is HTML-escaped inside a pre block.
+*/
+string renderReadmeHtml(string contents, string format,
+	string delegate(string, bool) urlFilter = null)
+{
+	import vibe.textfilter.html : htmlEscape;
+
+	switch (format.toLower) {
+		case "markdown", "md":
+			import vibe.textfilter.markdown : MarkdownFlags, MarkdownSettings, filterMarkdown;
+			scope msettings = new MarkdownSettings;
+			msettings.flags = MarkdownFlags.backtickCodeBlocks | MarkdownFlags.noInlineHtml | MarkdownFlags.tables;
+			msettings.headingBaseLevel = 2;
+			if (urlFilter !is null)
+				msettings.urlFilter = urlFilter;
+			return filterMarkdown(contents, msettings);
+		case "asciidoc", "adoc":
+			return renderAsciidocReadme(contents, urlFilter);
+		default:
+			return `<pre class="plain-readme">` ~ htmlEscape(contents) ~ `</pre>`;
+	}
+}
+
+private string renderAsciidocReadme(string contents,
+	string delegate(string, bool) urlFilter)
+{
+	import asciidoctor : ConvertOptions, convert;
+	import std.regex : ctRegex, replaceAll;
+	import std.uni : toLower;
+
+	ConvertOptions opts;
+	opts.backend = "html5";
+	opts.standalone = false;
+	opts.secure = true;
+	auto html = convert(contents, opts);
+
+	// Rewrite relative links/images similar to Markdown urlFilter when provided.
+	if (urlFilter !is null) {
+		static hrefRe = ctRegex!(`(?i)(<(?:a\s[^>]*href|img\s[^>]*src)=["'])([^"']+)(["'])`);
+		html = replaceAll!((c) {
+			auto url = c[2];
+			immutable isImage = c[1].toLower.canFind("<img");
+			return c[1] ~ urlFilter(url, isImage) ~ c[3];
+		})(html, hrefRe);
+	}
+
+	return sanitizeReadmeHtml(html);
+}
+
+/** Strip dangerous tags/attributes from README HTML (defense in depth). */
+string sanitizeReadmeHtml(string html)
+{
+	import std.regex : ctRegex, replaceAll;
+
+	// Drop script/style/iframe/object/embed/link/meta/form controls and their contents.
+	static dangerous = ctRegex!(
+		`(?is)<\s*(script|style|iframe|object|embed|link|meta|form|input|button|textarea|select)(\s[^>]*)?>.*?<\s*/\s*\1\s*>|<\s*(script|style|iframe|object|embed|link|meta|form|input|button|textarea|select)(\s[^>]*)?/?>`);
+	html = replaceAll(html, dangerous, "");
+
+	// Strip inline event handlers and javascript: URLs.
+	static onAttr = ctRegex!(`(?i)\s+on[a-z]+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)`);
+	html = replaceAll(html, onAttr, "");
+	static jsUrl = ctRegex!(`(?i)\s*(href|src)\s*=\s*(['"])\s*javascript:[^'"]*\2`);
+	html = replaceAll(html, jsUrl, ` $1="#"`);
+
+	return html;
+}
+
+unittest {
+	auto safe = sanitizeReadmeHtml(`<p>Hi</p><script>alert(1)</script><a href="javascript:alert(1)">x</a>`);
+	assert(safe.canFind("<p>Hi</p>"));
+	assert(!safe.canFind("<script"));
+	assert(!safe.canFind("javascript:"));
 }

--- a/source/dubregistry/web.d
+++ b/source/dubregistry/web.d
@@ -293,6 +293,9 @@ class DubRegistryWebFrontend {
 
 			auto gitVer = verinfo.version_;
 			gitVer = gitVer.startsWith("~") ? gitVer[1 .. $] : "v"~gitVer;
+			auto readmeFileName = versionInfo["readmeFile"].opt!string;
+			if (!readmeFileName.length)
+				readmeFileName = "README.md";
 			string urlFilter(string url, bool is_image)
 			{
 				if (url.startsWith("http://") || url.startsWith("https://"))
@@ -306,7 +309,7 @@ class DubRegistryWebFrontend {
 						// TODO: BitBucket + GitLab
 						case "github":
 							if (is_image) return format("https://github.com/%s/%s/raw/%s/%s", owner, project, gitVer, url);
-							else return format("https://github.com/%s/%s/blob/%s/%s", owner, project, gitVer, url.startsWith("#") ? "README.md" ~ url : url);
+							else return format("https://github.com/%s/%s/blob/%s/%s", owner, project, gitVer, url.startsWith("#") ? readmeFileName ~ url : url);
 					}
 				}
 
@@ -328,6 +331,9 @@ class DubRegistryWebFrontend {
 			auto packageName = pname;
 			auto registry = m_registry;
 			auto readmeContents = m_registry.getReadme(versionInfo, packageInfo["repository"].deserializeJson!DbRepository);
+			auto readmeFormat = versionInfo["readmeFormat"].opt!string;
+			if (!readmeFormat.length)
+				readmeFormat = "markdown";
 			//auto sampleURLs = ["test1", "test2"]; /* TODO: actually make this array exist and embed samples generated from repository */
 			string[] sampleURLs;
 			auto activeTab = req.query.get("tab", "info");
@@ -339,6 +345,7 @@ class DubRegistryWebFrontend {
 					packinfo,
 					versionInfo,
 					readmeContents,
+					readmeFormat,
 					sampleURLs,
 					urlFilter,
 					registry,

--- a/views/view_package.dt
+++ b/views/view_package.dt
@@ -47,6 +47,8 @@ block css
 	link(rel="stylesheet", type="text/css", href="#{req.rootDir}styles/common.css")
 	- if (readmeContents.length)
 		link(rel="stylesheet", type="text/css", href="#{req.rootDir}styles/markdown.css")
+		- if (readmeFormat == "asciidoc")
+			link(rel="stylesheet", type="text/css", href="#{req.rootDir}styles/asciidoc.css")
 
 block body
 	.main
@@ -114,13 +116,10 @@ block body
 		- bool renderedTabContent;
 		- if (activeTab == "info")
 			- if (readmeContents.length)
-				.repositoryReadme.markdown-body
-					- import vibe.textfilter.markdown : MarkdownFlags, MarkdownSettings, filterMarkdown;
-					- scope msettings = new MarkdownSettings;
-					- msettings.flags = MarkdownFlags.backtickCodeBlocks|MarkdownFlags.noInlineHtml|MarkdownFlags.tables;
-					- msettings.headingBaseLevel = 2;
-					- msettings.urlFilter = &urlFilter;
-					!= filterMarkdown(readmeContents, msettings)
+				- string readmeExtraClass = readmeFormat == "asciidoc" ? "asciidoc-body" : "";
+				.repositoryReadme.markdown-body(class=readmeExtraClass)
+					- import dubregistry.viewutils : renderReadmeHtml;
+					!= renderReadmeHtml(readmeContents, readmeFormat, &urlFilter)
 			- else
 				.repositoryReadme
 			- renderedTabContent = true;


### PR DESCRIPTION
## Summary
- Prefer `README.md`, then `README.adoc` / `README.asciidoc`, then bare `README`, then other `README*` files.
- Store `readmeFormat` / `readmeFile` and render AsciiDoc via [asciidoctor-d](https://github.com/dlang-supplemental/asciidoctor-d) (secure HTML fragment).
- Sanitize README HTML (strip script/style/handlers) and add light AsciiDoc CSS.
- Preserve historical default of Markdown filtering for older DB documents without `readmeFormat`.

Depends on fragment/secure support in asciidoctor-d (`feature/html5-fragment-safe`). Until that lands on a tagged release, `dub.sdl` points at that branch.

## Test plan
- [ ] Package with only `README.adoc` shows formatted Info tab (headings, lists, code)
- [ ] Package with `README.md` unchanged
- [ ] AsciiDoc passthrough / `javascript:` links are neutralized
- [ ] Relative image/link rewriting still works for GitHub packages

Made with [Cursor](https://cursor.com)