### PR TITLE
Add GET /my_packages/:name/webhook status endpoint

### DIFF
--- a/api-docs/http-update.md
+++ b/api-docs/http-update.md
@@ -2,6 +2,20 @@
 
 To queue an update of your package you can use the `POST /api/packages/:packageName/update` endpoint.
 
+## `GET /my_packages/:packageName/webhook` (authenticated)
+
+Returns whether a webhook secret is configured for the package **without regenerating it**.
+
+Requires a logged-in package admin session (same auth as the My packages UI / `regen_secret`).
+
+Response JSON:
+
+```json
+{"package":"mypkg","configured":true}
+```
+
+The plaintext secret is intentionally never returned here — it is only shown once after `POST .../regen_secret`.
+
 ## `POST /api/packages/:packageName/update`
 
 Queues an update for the specified package.

--- a/source/dubregistry/dbcontroller.d
+++ b/source/dubregistry/dbcontroller.d
@@ -227,6 +227,15 @@ class DbController {
 		else return validateBcryptHash(ret.get.get!string, secret);
 	}
 
+	/// True when a webhook secret hash is stored (does not reveal the plaintext).
+	bool hasPackageSecret(string packname)
+	{
+		auto ret = m_packages.findOne(["name": packname]).tryIndex("secret");
+		if (ret.isNull) return false;
+		auto hash = ret.get.get!string;
+		return hash.length > 0;
+	}
+
 	void setPackageSecret(string packname, string secret)
 	{
 		// can be calculated "relatively quickly", being 4x faster than the usual password hashing - state of 2026

--- a/source/dubregistry/registry.d
+++ b/source/dubregistry/registry.d
@@ -462,6 +462,12 @@ class DubRegistry {
 		return m_db.validatePackageSecret(pack_name, secret);
 	}
 
+	/// Whether a webhook secret is configured (boolean only; plaintext is never returned).
+	bool hasPackageSecret(string pack_name)
+	{
+		return m_db.hasPackageSecret(pack_name);
+	}
+
 	void unsetPackageSecret(string pack_name)
 	{
 		m_db.setPackageSecret(pack_name, null);

--- a/source/dubregistry/web.d
+++ b/source/dubregistry/web.d
@@ -736,6 +736,18 @@ class DubRegistryFullWebFrontend : DubRegistryWebFrontend {
 		redirect("/my_packages/"~_packname~"#repository");
 	}
 
+	/// Non-destructive webhook status for package admins / tooling.
+	/// Returns JSON `{"package":"...","configured":true|false}` — never the plaintext secret.
+	@auth @path("/my_packages/:packname/webhook")
+	void getPackageWebhook(scope HTTPServerRequest request, scope HTTPServerResponse response, string _packname, User _user)
+	{
+		enforceUserPackage(_user, _packname, DbPackage.Permissions.admin);
+		Json ret = Json.emptyObject;
+		ret["package"] = _packname;
+		ret["configured"] = m_registry.hasPackageSecret(_packname);
+		response.writeJsonBody(ret);
+	}
+
 	@auth @path("/my_packages/:packname/update")
 	void postUpdatePackage(string _packname, User _user)
 	{


### PR DESCRIPTION
## Summary
- Add authenticated `GET /my_packages/:packname/webhook` returning JSON `{package,configured}` without regenerating the secret
- Add `hasPackageSecret` on the DB/registry layers
- Document the endpoint in `api-docs/http-update.md`

Fixes https://github.com/dlang/dub-registry/issues/617

## Motivation
Owner tooling (e.g. dub-publish) needs to check whether webhooks are enabled. The only existing owner HTTP actions are `regen_secret` (destructive rotate) and `unset_secret`. Scraping the My packages HTML works but is fragile; calling `regen_secret` to check status invalidates forge webhook URLs.

Plaintext secrets remain one-shot after regenerate — this endpoint only exposes a boolean.

## Test plan
- [ ] As package admin, `GET /my_packages/:name/webhook` with session cookie returns `configured:false` before enable
- [ ] After Enable Webhooks / `regen_secret`, same GET returns `configured:true`
- [ ] Non-admin / unauthenticated requests are rejected
- [ ] Response never includes the plaintext secret